### PR TITLE
Add support for managing asynchronous requests

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -14,7 +14,11 @@ class Compression {
    */
   async handle({ request, response }, next) {
     const [{ request: req }, { response: res }] = [request, response];
-    this.compression(req, res, next);
+
+    // compression() is not async itself and next() should be managed using asynchronous API.
+    this.compression(req, res, () => {});
+
+    await next();
   }
 }
 


### PR DESCRIPTION
In order to be able to compress asynchronous requests |next()|
should be managed using `await` keyword.
Compression is not asynchronous itself and simply call |next()|
at the end.

Co-authored-by: Andrew Jo <andrew@verdigris.co>
Co-authored-by: Hannah Hagen <hannah@verdigris.co>